### PR TITLE
🐛 font path를 절대경로가 아닌 상대경로로 변경

### DIFF
--- a/app/_styles/globals.scss
+++ b/app/_styles/globals.scss
@@ -12,26 +12,17 @@ mark {
 
 @font-face {
   font-family: 'ALfont';
-  src:
-    url('/fonts/mainfont.woff2') format('woff2'),
-    url('/fonts/mainfont.woff') format('woff'),
-    url('/fonts/mainfont.ttf') format('truetype');
+  src: url('../../public/fonts/mainfont.woff2') format('woff2');
 }
 
 @font-face {
   font-family: 'KRfont';
-  src:
-    url('/fonts/mainfontKR.woff2') format('woff2'),
-    url('/fonts/mainfontKR.woff') format('woff'),
-    url('/fonts/mainfontKR.ttf') format('truetype');
+  src: url('../../public/fonts/mainfontKR.woff2') format('woff2');
 }
 
 @font-face {
   font-family: 'ENfont';
-  src:
-    url('/fonts/mainfontEN.woff2') format('woff2'),
-    url('/fonts/mainfontEN.woff') format('woff'),
-    url('/fonts/mainfontEN.ttf') format('truetype');
+  src: url('../../public/fonts/mainfontEN.ttf') format('truetype');
   unicode-range: U+0041-005A, U+0061-007A;
 }
 

--- a/app/_styles/mdx.scss
+++ b/app/_styles/mdx.scss
@@ -1,6 +1,6 @@
 @font-face {
   font-family: 'codefont';
-  src: url('/public/fonts/codefont.woff2') format('woff2');
+  src: url('../../public/fonts/codefont.woff2') format('woff2');
 }
 .post-wrapper {
   // 콜아웃


### PR DESCRIPTION
## summary

변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요.

- Resolves: #121 

## PR 유형

어떤 유형인가요? 해당되는 유형에 체크해주세요.

**PR 제목 작성시 '[유형에 맞는 gitmoji] 제목'으로 입력 부탁드립니다.**

- [ ] ✨ Feature / 새로운 기능
- [x] 🐛 Fix / 버그 수정
- [ ] 💄 Style / CSS 등 사용자 UI 디자인 변경
- [ ] ♻️ Refactor / 코드 리팩토링(구조 개선, 디렉토리 변경 등...)
- [ ] 📝 Docs / 문서 수정
- [ ] ✅ Test / 테스트 추가, 테스트 리팩토링
- [ ] 💬 Chore / 그 외, 모든 변경점(Package, Rename, Remove, etc...)

## 변경 사항

| 기능  | 스크린샷 |
| :---: | -------- |
| As-is |![image](https://github.com/nerd-animals/na-log-engine/assets/144116866/16fbf600-43d8-46e9-8d6b-4f9eca00d678)<img width="443" alt="image" src="https://github.com/nerd-animals/na-log-engine/assets/144116866/2964c5aa-7e5d-42c6-ab9c-fd34b0e74e08">|
| To-be |![image](https://github.com/nerd-animals/na-log-engine/assets/144116866/ed8753a7-91e3-4b52-9eca-ff5cf872eb70)<img width="451" alt="image" src="https://github.com/nerd-animals/na-log-engine/assets/144116866/68547479-9cf7-4912-a4fe-3f06a9951df3">|

---

`절대 경로`로 지정했을 시 font가 static/media 폴더 안에 저장이 되지 않은 채로 build가 되며, css 내부 url에도 path가 그대로 올라갑니다.
`상대 경로`로 지정했을 시 font가 static/media 폴더 안에 저장이 된 채로 build가 되며, css 내부에도 font를 지정해줍니다.


<img width="294" alt="image" src="https://github.com/nerd-animals/na-log-engine/assets/144116866/f47734d2-7cdb-454f-b559-d43517f45d04">

따라서, gh-pages에 build가 되더라도 위와 같이 font asset이 static 폴더에 build 되고, css 내부의 path는 basePath까지 붙은 경로로 변경되어 정상적으로 폰트 인식을 할 것으로 예상됩니다.

<img width="674" alt="image" src="https://github.com/nerd-animals/na-log-engine/assets/144116866/f5658f57-6e44-4a32-85ab-41f50830a2bd">

하지만, 이 경우 없는 폰트에 대해서는 찾을 수 없다는 에러가 뜹니다.
원래 기능으로는 폰트 타입 세 가지(woff2, woff, truetype) 중 하나만 선택해서 넣더라도 인식을 하게끔 하려고 했으나, 이 방법에 대해서는 다시 논의해봐야할 것 같습니다.

[관련 링크](https://hini7.tistory.com/243#toc-%ED%95%B4%EA%B2%B0)

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 정상 동작 확인 여부
- [x] commit message convention 충족 여부
